### PR TITLE
feat: added FilterableMultiSelect in an example

### DIFF
--- a/react/filterPanel/src/Example/Example.tsx
+++ b/react/filterPanel/src/Example/Example.tsx
@@ -1,5 +1,6 @@
 import { Grid, Column } from '@carbon/react';
 import { FilterPanel } from './FilterPanel';
+import { WithFilterableMultiSelect } from './WithFilterableMultiSelect';
 import './example.scss';
 
 export const Example = () => (
@@ -7,5 +8,9 @@ export const Example = () => (
     <Column sm={4} md={8} lg={16}>
       <FilterPanel />
     </Column>
+    <Column sm={4} md={8} lg={16}>
+      <WithFilterableMultiSelect />
+    </Column>
   </Grid>
 );
+


### PR DESCRIPTION
closes #12 

adds an example with FilterableMultiSelect replacing checkboxes

A use case was discussed based on the Slack conversation, where the user requires a type-ahead feature similar to the one in FilterableMultiSelect. This approach is preferred when there are numerous filter options, as FilterableMultiSelect offers a more efficient solution compared to checkboxes, which may clutter the panel.