### PR TITLE
feat: WC customize columns add DND

### DIFF
--- a/web-components/customize-columns/index.html
+++ b/web-components/customize-columns/index.html
@@ -1,15 +1,19 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit + TS</title>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon-for-ibm-dotcom/tag/v1/latest/plex.css" />
     <link rel="stylesheet" href="./src/index.scss" />
     <script type="module" src="/src/basic.ts"></script>
+    <script type="module" src="/src/theme-selector.ts"></script>
   </head>
   <body>
     <basic-tanstack-table></basic-tanstack-table>
+    <theme-selector></theme-selector>
   </body>
 </html>

--- a/web-components/customize-columns/package.json
+++ b/web-components/customize-columns/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@carbon/ibm-products-web-components": "^0.15.0",
     "@carbon/styles": "^1.34.0",
     "@carbon/web-components": "latest",
     "@dnd-kit/dom": "^0.0.6-beta-20240919012756",

--- a/web-components/customize-columns/src/basic.ts
+++ b/web-components/customize-columns/src/basic.ts
@@ -210,13 +210,11 @@ export class MyBasicTable extends LitElement {
                 .columnVisibilityTemp=${this._columnVisibilityTemp}
                 .setColumnOrderTemp=${(order: string[]) => {
                   this._columnOrderTemp = order;
-                  this.requestUpdate();
                 }}
                 .setColumnVisibilityTemp=${(
                   visibility: Record<string, boolean>
                 ) => {
                   this._columnVisibilityTemp = visibility;
-                  this.requestUpdate();
                 }}>
               </dnd-example>
             </div>`;

--- a/web-components/customize-columns/src/basic.ts
+++ b/web-components/customize-columns/src/basic.ts
@@ -202,7 +202,7 @@ export class MyBasicTable extends LitElement {
         ${repeat(
           table.getHeaderGroups(),
           (headerGroup) => headerGroup.id,
-          (headerGroup) => {
+          () => {
             return html` <div class="drag-wrapper">
               <dnd-example
                 .items=${table.getAllLeafColumns()}

--- a/web-components/customize-columns/src/dnd-example.scss
+++ b/web-components/customize-columns/src/dnd-example.scss
@@ -1,0 +1,69 @@
+@use '@carbon/styles/scss/theme' as *;
+@use '@carbon/styles/scss/themes';
+@use '@carbon/styles/scss/spacing' as *;
+@use '@carbon/styles/scss/colors';
+@use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/utilities';
+
+:root {
+  @include theme(themes.$white);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+
+:host {
+  width: 100%;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  background: $layer-02;
+  cursor: grab;
+  padding: 0.5rem;
+  border-block-end: 1px solid $border-subtle-01;
+
+  &.dragging {
+    opacity: 0.4;
+    @include utilities.focus-outline('outline');
+    outline-offset: -2px;
+  }
+
+  &:active {
+    cursor: grabbing;
+  }
+
+  &:focus {
+    @include utilities.focus-outline('outline');
+  }
+
+  &.drag-over {
+    outline: 2px dashed $focus;
+    outline-offset: -2px;
+  }
+}
+
+.drag-icon {
+  margin-block-start: 0.4rem;
+}
+
+.li-content {
+  display: flex;
+  gap: 0.5rem;
+  padding-inline-start: 1rem;
+  align-items: center;
+}
+
+cds-checkbox {
+  margin-block-end: 0;
+  flex: none;
+}

--- a/web-components/customize-columns/src/dnd-example.scss
+++ b/web-components/customize-columns/src/dnd-example.scss
@@ -33,8 +33,9 @@ li {
   border-block-end: 1px solid $border-subtle-01;
 
   &.dragging {
-    opacity: 0.4;
     @include utilities.focus-outline('outline');
+
+    opacity: 0.4;
     outline-offset: -2px;
   }
 

--- a/web-components/customize-columns/src/dnd-example.ts
+++ b/web-components/customize-columns/src/dnd-example.ts
@@ -28,20 +28,10 @@ export class DndExample extends LitElement {
 
   private dragStartIndex: number = -1;
 
-  updated(changedProperties: Map<string, any>) {
-    if (
-      changedProperties.has('items') ||
-      changedProperties.has('columnOrderTemp')
-    ) {
-      this.requestUpdate();
-    }
-  }
-
   private handleDragStart(e: DragEvent, index: number) {
     this.dragStartIndex = index;
     if (e.target instanceof HTMLElement) {
       e.target.classList.add('dragging');
-      e.target.blur();
     }
   }
 
@@ -66,28 +56,21 @@ export class DndExample extends LitElement {
     newOrder.splice(dropIndex, 0, draggedItem);
 
     this.setColumnOrderTemp(newOrder);
-    this.requestUpdate();
 
     const draggingElement = this.shadowRoot?.querySelector('.dragging');
     if (draggingElement) {
       draggingElement.classList.remove('dragging');
-    }
-
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur();
     }
   }
 
   private handleDragEnd(e: DragEvent) {
     if (e.target instanceof HTMLElement) {
       e.target.classList.remove('dragging');
-      e.target.blur();
     }
 
     const li = this.shadowRoot?.querySelectorAll('li');
     li?.forEach((item) => {
       item.classList.remove('drag-over');
-      item.blur();
     });
   }
 
@@ -97,7 +80,6 @@ export class DndExample extends LitElement {
       [columnId]: checked,
     };
     this.setColumnVisibilityTemp(newVisibility);
-    this.requestUpdate();
   }
 
   render() {

--- a/web-components/customize-columns/src/dnd-example.ts
+++ b/web-components/customize-columns/src/dnd-example.ts
@@ -106,6 +106,7 @@ export class DndExample extends LitElement {
                   ${(() => {
                     const col = this.items.find((col) => col.id === item);
                     const header = col?.columnDef?.header;
+                    // @ts-ignore
                     return typeof header === 'function' ? header() : header;
                   })()}
                 </cds-checkbox>

--- a/web-components/customize-columns/src/dnd-example.ts
+++ b/web-components/customize-columns/src/dnd-example.ts
@@ -1,0 +1,147 @@
+import { LitElement, css, html, unsafeCSS } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import '@carbon/web-components/es/components/checkbox/index.js';
+import Draggable from '@carbon/web-components/es/icons/draggable/16.js';
+import '@carbon/web-components/es/components/icon-button/index.js';
+
+import styles from './dnd-example.scss?inline';
+import { repeat } from 'lit/directives/repeat.js';
+import { Column } from '@tanstack/lit-table';
+
+@customElement('dnd-example')
+export class DndExample extends LitElement {
+  @property({ type: Array })
+  items: Column<any, unknown>[] = [];
+
+  @property({ type: Array })
+  columnOrderTemp: string[] = [];
+
+  @property({ type: Object })
+  columnVisibilityTemp: Record<string, boolean> = {};
+
+  @property()
+  setColumnOrderTemp!: (order: string[]) => void;
+
+  @property()
+  setColumnVisibilityTemp!: (visibility: Record<string, boolean>) => void;
+
+  private dragStartIndex: number = -1;
+
+  updated(changedProperties: Map<string, any>) {
+    if (
+      changedProperties.has('items') ||
+      changedProperties.has('columnOrderTemp')
+    ) {
+      this.requestUpdate();
+    }
+  }
+
+  private handleDragStart(e: DragEvent, index: number) {
+    this.dragStartIndex = index;
+    if (e.target instanceof HTMLElement) {
+      e.target.classList.add('dragging');
+      e.target.blur();
+    }
+  }
+
+  private handleDragOver(e: DragEvent) {
+    e.preventDefault();
+    const target = e.currentTarget as HTMLElement;
+    target.classList.add('drag-over');
+  }
+
+  private handleDragLeave(e: DragEvent) {
+    const target = e.currentTarget as HTMLElement;
+    target.classList.remove('drag-over');
+  }
+
+  private handleDrop(e: DragEvent, dropIndex: number) {
+    e.preventDefault();
+    const target = e.currentTarget as HTMLElement;
+    target.classList.remove('drag-over');
+
+    const newOrder = [...this.columnOrderTemp];
+    const [draggedItem] = newOrder.splice(this.dragStartIndex, 1);
+    newOrder.splice(dropIndex, 0, draggedItem);
+
+    this.setColumnOrderTemp(newOrder);
+    this.requestUpdate();
+
+    const draggingElement = this.shadowRoot?.querySelector('.dragging');
+    if (draggingElement) {
+      draggingElement.classList.remove('dragging');
+    }
+
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+  }
+
+  private handleDragEnd(e: DragEvent) {
+    if (e.target instanceof HTMLElement) {
+      e.target.classList.remove('dragging');
+      e.target.blur();
+    }
+
+    const li = this.shadowRoot?.querySelectorAll('li');
+    li?.forEach((item) => {
+      item.classList.remove('drag-over');
+      item.blur();
+    });
+  }
+
+  private handleCheckboxChange(columnId: string, checked: boolean) {
+    const newVisibility = {
+      ...this.columnVisibilityTemp,
+      [columnId]: checked,
+    };
+    this.setColumnVisibilityTemp(newVisibility);
+    this.requestUpdate();
+  }
+
+  render() {
+    return html`
+      <ol>
+        ${repeat(
+          this.columnOrderTemp,
+          (item) => item,
+          (item, index) => html`
+            <li
+              draggable="true"
+              tabindex="0"
+              @dragstart="${(e: DragEvent) => this.handleDragStart(e, index)}"
+              @dragover="${this.handleDragOver}"
+              @dragleave="${this.handleDragLeave}"
+              @drop="${(e: DragEvent) => this.handleDrop(e, index)}"
+              @dragend="${this.handleDragEnd}">
+              <div class="li-content">
+                <div class="drag-icon">${Draggable({ slot: 'icon' })}</div>
+                <cds-checkbox
+                  ?checked=${this.columnVisibilityTemp[item]}
+                  @cds-checkbox-changed=${(e: CustomEvent) =>
+                    this.handleCheckboxChange(item, e.detail.checked)}>
+                  ${(() => {
+                    const col = this.items.find((col) => col.id === item);
+                    const header = col?.columnDef?.header;
+                    return typeof header === 'function' ? header() : header;
+                  })()}
+                </cds-checkbox>
+              </div>
+            </li>
+          `
+        )}
+      </ol>
+    `;
+  }
+
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'dnd-example': DndExample;
+  }
+}

--- a/web-components/customize-columns/src/index.scss
+++ b/web-components/customize-columns/src/index.scss
@@ -8,3 +8,31 @@
   background-color: var(--cds-background);
   color: var(--cds-text-primary);
 }
+
+[data-carbon-theme='g10'] {
+  @include theme.theme(themes.$g10);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+
+[data-carbon-theme='g90'] {
+  @include theme.theme(themes.$g90);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+
+[data-carbon-theme='g100'] {
+  @include theme.theme(themes.$g100);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}
+
+[data-carbon-theme='white'] {
+  @include theme.theme(themes.$white);
+
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
+}

--- a/web-components/customize-columns/src/theme-selector.ts
+++ b/web-components/customize-columns/src/theme-selector.ts
@@ -1,0 +1,59 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import '@carbon/web-components/es/components/dropdown/index.js';
+
+@customElement('theme-selector')
+export class ThemeSelector extends LitElement {
+  @state()
+  private currentTheme: string = 'g100';
+
+  private handleThemeChange(e: CustomEvent) {
+    const selectedValue = (e.target as HTMLSelectElement).value;
+    this.setTheme(selectedValue);
+  }
+
+  private setTheme(theme: string) {
+    document.documentElement.setAttribute('data-carbon-theme', theme);
+    localStorage.setItem('carbon-theme', theme);
+    this.currentTheme = theme;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    const savedTheme = localStorage.getItem('carbon-theme');
+    if (savedTheme) {
+      this.setTheme(savedTheme);
+    }
+  }
+
+  render() {
+    return html`
+      <cds-dropdown
+        class="theme-selector"
+        direction="top"
+        title-text="Select theme"
+        value=${this.currentTheme}
+        @cds-dropdown-selected=${this.handleThemeChange}>
+        <cds-dropdown-item value="white">White</cds-dropdown-item>
+        <cds-dropdown-item value="g10">G10</cds-dropdown-item>
+        <cds-dropdown-item value="g90">G90</cds-dropdown-item>
+        <cds-dropdown-item value="g100">G100</cds-dropdown-item>
+      </cds-dropdown>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      z-index: 1000;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'theme-selector': ThemeSelector;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,6 +191,13 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
+"@carbon/colors@^11.33.0":
+  version "11.33.0"
+  resolved "https://registry.yarnpkg.com/@carbon/colors/-/colors-11.33.0.tgz#ba274ced868dcb4e496e1d3ab160476212cb2a1e"
+  integrity sha512-TiD4LYADMaVWqYBLmxWSya1SZaLn7KM1NnWiF7V18xI3YDc0zLhodk8JPvh8OERYcG1zc4+GeI/FHeNtankLLA==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/feature-flags@^0.24.0":
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/@carbon/feature-flags/-/feature-flags-0.24.1.tgz#f5b5b87da8186263b296ec3964df48c2b09c747d"
@@ -213,12 +220,38 @@
     "@carbon/layout" "^11.32.0"
     "@ibm/telemetry-js" "^1.5.0"
 
+"@carbon/grid@^11.36.0":
+  version "11.36.0"
+  resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.36.0.tgz#5b4216ad6f443f7c0aba837ffacae1e26a72446e"
+  integrity sha512-wYSHLnTw0rCjumBm/OB8H8H/rJR0MJpvBCnBtK6BCPh/vBTnpFX05MgzskZISkoAUomLbExbI6PtxfT5ZmgDMg==
+  dependencies:
+    "@carbon/layout" "^11.34.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/ibm-products-styles@^2.60.0":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@carbon/ibm-products-styles/-/ibm-products-styles-2.60.0.tgz#2067ee0f77b6b746264444965223e6ad1ec90faf"
   integrity sha512-g8PpqhsCjcTz/IvGHgv0jFdaAORLSp+/aVoh4OaYJSnRAmnfgDn+ao92eR7cAdWnGSFV6QIkS5wqIdrYURhrvw==
   dependencies:
     "@ibm/telemetry-js" "^1.9.1"
+
+"@carbon/ibm-products-styles@^2.62.0":
+  version "2.62.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibm-products-styles/-/ibm-products-styles-2.62.0.tgz#d2049f99916c0311d9c48eeb1d8e71f5a2af55f3"
+  integrity sha512-I+SXT4srBC8HjrsTo3VCI8i5cr2Ba7zu6OtvR9bnY4repWy7gnV76p8h3XaKiWK4EYYG3VQ8FAADXYITHdoNlw==
+  dependencies:
+    "@ibm/telemetry-js" "^1.9.1"
+
+"@carbon/ibm-products-web-components@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@carbon/ibm-products-web-components/-/ibm-products-web-components-0.15.0.tgz#5fc50e6764d97f3f991440cb37ec74cd44158dd6"
+  integrity sha512-r8AG3Fsn/Rs8xT+7EY8vJeTD8Eej0RqXVH8X0e94dtp7ENhQQogpHdrzcJ1gfekUhPLWysnEqTH0jg47ow5o5w==
+  dependencies:
+    "@carbon/ibm-products-styles" "^2.62.0"
+    "@carbon/styles" "1.79.0"
+    "@carbon/web-components" "2.27.1"
+    "@ibm/telemetry-js" "^1.9.1"
+    lit "^3.1.0"
 
 "@carbon/ibm-products@^2.47.0", "@carbon/ibm-products@^2.50.0":
   version "2.64.0"
@@ -261,10 +294,24 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
+"@carbon/layout@^11.34.0":
+  version "11.34.0"
+  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-11.34.0.tgz#4a76c3cb1a82c8f8e5f07059ec75ed9939f07e71"
+  integrity sha512-6PMofb/Ul/CZkP1XivszK2teh0odPV/bUG/PPQlVX1xnFdc+4O9o08JnFG9N2Ie6syncOXRCf8z1CegpV28x9A==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/motion@^11.26.0":
   version "11.26.0"
   resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.26.0.tgz#347eea512267438327095b1a3b37d98c3bdbb6b4"
   integrity sha512-Siy5cgi23dW6BtrA2AN+cvpjiEWmNFqeDWeiYtIbQX9OWjjTMDWJYs3K0QzGlqByx/ZIShqs8vLeDz7hYAjP9Q==
+  dependencies:
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/motion@^11.28.0":
+  version "11.28.0"
+  resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-11.28.0.tgz#af8f80dc4d0487993a17cbed9c52c841e16678d7"
+  integrity sha512-bKzw6XXGJJolGZbD4JMm+17rJY8Sjy7Xc7W/ktAtWLDf1IwBeV6dJelcF2xaxOqa7ITUhr+HX5BtsHVcrBcJwQ==
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
@@ -292,6 +339,29 @@
     use-resize-observer "^9.1.0"
     window-or-global "^1.0.1"
 
+"@carbon/styles@1.79.0":
+  version "1.79.0"
+  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.79.0.tgz#655cc6fb7203a010f80c43eb48358bc0334cb244"
+  integrity sha512-dpmG+sdnciWVVCSmgznkqj0/G6BG+JsAeL/G1UHcsGHwKUN95mgZNQiWNTV7SphaHyjnp3h+KiE0n4Rc6faPMg==
+  dependencies:
+    "@carbon/colors" "^11.31.0"
+    "@carbon/feature-flags" "^0.26.0"
+    "@carbon/grid" "^11.34.0"
+    "@carbon/layout" "^11.32.0"
+    "@carbon/motion" "^11.26.0"
+    "@carbon/themes" "^11.50.0"
+    "@carbon/type" "^11.38.0"
+    "@ibm/plex" "6.0.0-next.6"
+    "@ibm/plex-mono" "0.0.3-alpha.0"
+    "@ibm/plex-sans" "0.0.3-alpha.0"
+    "@ibm/plex-sans-arabic" "0.0.3-alpha.0"
+    "@ibm/plex-sans-devanagari" "0.0.3-alpha.0"
+    "@ibm/plex-sans-hebrew" "0.0.3-alpha.0"
+    "@ibm/plex-sans-thai" "0.0.3-alpha.0"
+    "@ibm/plex-sans-thai-looped" "0.0.3-alpha.0"
+    "@ibm/plex-serif" "0.0.3-alpha.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
 "@carbon/styles@^1.34.0", "@carbon/styles@^1.71.0", "@carbon/styles@^1.79.1":
   version "1.79.1"
   resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.79.1.tgz#8e81c46f6c40aa1e7f1fed364d75c3248215df56"
@@ -304,6 +374,29 @@
     "@carbon/motion" "^11.26.0"
     "@carbon/themes" "^11.50.0"
     "@carbon/type" "^11.38.0"
+    "@ibm/plex" "6.0.0-next.6"
+    "@ibm/plex-mono" "0.0.3-alpha.0"
+    "@ibm/plex-sans" "0.0.3-alpha.0"
+    "@ibm/plex-sans-arabic" "0.0.3-alpha.0"
+    "@ibm/plex-sans-devanagari" "0.0.3-alpha.0"
+    "@ibm/plex-sans-hebrew" "0.0.3-alpha.0"
+    "@ibm/plex-sans-thai" "0.0.3-alpha.0"
+    "@ibm/plex-sans-thai-looped" "0.0.3-alpha.0"
+    "@ibm/plex-serif" "0.0.3-alpha.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/styles@^1.79.0":
+  version "1.82.0"
+  resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.82.0.tgz#143c4a8e1d3c442a232a62c873f5024e4f07b82d"
+  integrity sha512-WgwWIoXHb/nsov+mfqbiH9G8fQ7qp8pgspZGsIypg0Ym77b9/AOGL2ODC/uIjUt+FeNKjqm0/C5hi3ldu0iF8A==
+  dependencies:
+    "@carbon/colors" "^11.33.0"
+    "@carbon/feature-flags" "^0.26.0"
+    "@carbon/grid" "^11.36.0"
+    "@carbon/layout" "^11.34.0"
+    "@carbon/motion" "^11.28.0"
+    "@carbon/themes" "^11.53.0"
+    "@carbon/type" "^11.40.0"
     "@ibm/plex" "6.0.0-next.6"
     "@ibm/plex-mono" "0.0.3-alpha.0"
     "@ibm/plex-sans" "0.0.3-alpha.0"
@@ -331,6 +424,17 @@
     "@ibm/telemetry-js" "^1.5.0"
     color "^4.0.0"
 
+"@carbon/themes@^11.53.0":
+  version "11.53.0"
+  resolved "https://registry.yarnpkg.com/@carbon/themes/-/themes-11.53.0.tgz#b3505acfce67f073f00e853afa190c259238965d"
+  integrity sha512-b3gH7NvTA5+cP+9GQPFLOaw58QTz8bCjCKJ18WmiMn3oSNKlcj9dlC/9Ey6QYmUA1gSJQR3VlsYfZmlCrZseFQ==
+  dependencies:
+    "@carbon/colors" "^11.33.0"
+    "@carbon/layout" "^11.34.0"
+    "@carbon/type" "^11.40.0"
+    "@ibm/telemetry-js" "^1.5.0"
+    color "^4.0.0"
+
 "@carbon/type@^11.38.0":
   version "11.38.0"
   resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.38.0.tgz#6c782729aa6a91b2df74a7af07653efb2fdf4f3b"
@@ -338,6 +442,15 @@
   dependencies:
     "@carbon/grid" "^11.34.0"
     "@carbon/layout" "^11.32.0"
+    "@ibm/telemetry-js" "^1.5.0"
+
+"@carbon/type@^11.40.0":
+  version "11.40.0"
+  resolved "https://registry.yarnpkg.com/@carbon/type/-/type-11.40.0.tgz#b83f8964b39c27e604cf2bd682d079411401d975"
+  integrity sha512-0mGg6wO+Ev5uQULFIDVny8ODZ47XPQuf0x0U67XNMo4GblpiufD+q8IyODrsdFKP/EermeJegCHGzwNLCilvIg==
+  dependencies:
+    "@carbon/grid" "^11.36.0"
+    "@carbon/layout" "^11.34.0"
     "@ibm/telemetry-js" "^1.5.0"
 
 "@carbon/utilities@^0.4.0":
@@ -355,6 +468,20 @@
     "@carbon/styles" "^1.71.0"
     "@floating-ui/dom" "^1.6.3"
     "@ibm/telemetry-js" "^1.5.0"
+    flatpickr "4.6.13"
+    lit "^3.1.0"
+    lodash-es "^4.17.21"
+    tslib "^2.6.3"
+
+"@carbon/web-components@2.27.1":
+  version "2.27.1"
+  resolved "https://registry.yarnpkg.com/@carbon/web-components/-/web-components-2.27.1.tgz#91813fc02df6ad81f0272a275697e78811f79857"
+  integrity sha512-14FXj4HrcRQ3SpxhhEOwoKp15QSMIXPBbwEX3iemqztjU+8ciSO3+ZbQTh5xUEs919rBQaFEkBsV7LXB0nU0Sg==
+  dependencies:
+    "@carbon/styles" "^1.79.0"
+    "@floating-ui/dom" "^1.6.3"
+    "@ibm/telemetry-js" "^1.5.0"
+    "@lit/context" "^1.1.1"
     flatpickr "4.6.13"
     lit "^3.1.0"
     lodash-es "^4.17.21"


### PR DESCRIPTION
closes [#7564](https://github.com/carbon-design-system/ibm-products/issues/7564) in ibm-products

adds DND feature to WC customizable columns story, until we decide if we want to have a seperate library for DND. 
this pr however adds browser native DND and makes this example fully functional, without any blockers.

preview: https://stackblitz.com/github/devadula-nandan/tanstack-carbon/tree/feat/customise-columns-wc-dnd/web-components/customize-columns