### PR TITLE
feat: full table gradient

### DIFF
--- a/react/ai-label/src/Example/Example.tsx
+++ b/react/ai-label/src/Example/Example.tsx
@@ -3,6 +3,7 @@ import { SortableWithAiLabel } from './SortableWithAiLabel';
 import { ColumnWithAiLabel } from './ColumnWithAiLabel';
 import { WithSelection } from './WithSelection';
 import './example.scss';
+import { FullTableAI } from './FullTableAi';
 
 export const Example = () => (
   <Grid className="page-grid">
@@ -14,6 +15,9 @@ export const Example = () => (
     </Column>
     <Column sm={4} md={8} lg={8}>
       <WithSelection />
+    </Column>
+    <Column sm={4} md={8} lg={8}>
+      <FullTableAI />
     </Column>
   </Grid>
 );

--- a/react/ai-label/src/Example/ExampleAiLabel.tsx
+++ b/react/ai-label/src/Example/ExampleAiLabel.tsx
@@ -4,16 +4,24 @@ import {
   AILabelContent,
   Button,
   IconButton,
+  AILabelProps,
 } from '@carbon/react';
 import { FolderOpen, Folders, View } from '@carbon/react/icons';
 import cx from 'classnames';
 
-export const ExampleAiLabel = ({ isRowAILabel = false }): JSX.Element => (
+interface CustomAILabelProps extends AILabelProps {
+  isRowAILabel?: boolean;
+}
+export const ExampleAiLabel = ({
+  className,
+  isRowAILabel = false,
+  size = 'mini',
+}: CustomAILabelProps): JSX.Element => (
   <AILabel
-    className={cx({ ['ai-label-container']: !isRowAILabel })}
+    className={cx(className, { ['ai-label-container']: !isRowAILabel })}
     autoAlign
     align="bottom-right"
-    size="mini">
+    size={size}>
     <AILabelContent>
       <div>
         <p className="secondary">AI Explained</p>

--- a/react/ai-label/src/Example/FullTableAi.tsx
+++ b/react/ai-label/src/Example/FullTableAi.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { DataTable, TableContainer } from '@carbon/react';
+import cx from 'classnames';
+import { ExampleAiLabel } from './ExampleAiLabel';
+
+const { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } =
+  DataTable;
+
+import { makeData, Resource } from './makeData';
+
+export const FullTableAI = () => {
+  const columns = React.useMemo<ColumnDef<Resource>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        cell: (info) => info.getValue(),
+        header: () => <span>Name</span>,
+      },
+      {
+        accessorFn: (row) => row.rule,
+        id: 'rule',
+        cell: (info) => info.getValue(),
+        header: () => <span>Rule</span>,
+      },
+      {
+        accessorKey: 'status',
+        header: () => 'Status',
+      },
+      {
+        accessorKey: 'other',
+        header: () => <span>Other</span>,
+      },
+      {
+        accessorKey: 'example',
+        header: 'Example',
+      },
+    ],
+    []
+  );
+
+  const [data] = React.useState(() => makeData(1000));
+
+  const table = useReactTable({
+    columns,
+    data,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <TableContainer title="Full table" className="tanstack-example">
+      <Table className="ai-column-example full-table-ai">
+        <TableHead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                const slug = header.column.columnDef.meta?.slug;
+                const SlugComponent =
+                  typeof slug === 'function'
+                    ? header.column.columnDef.meta?.slug
+                    : null;
+                return (
+                  <TableHeader
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    className={cx([
+                      'ai-column',
+                      { ['ai-label-is-present']: typeof slug !== 'undefined' },
+                    ])}>
+                    {header.isPlaceholder ? null : (
+                      <>
+                        {header.isPlaceholder
+                          ? null
+                          : flexRender(
+                              header.column.columnDef.header,
+                              header.getContext()
+                            )}
+                        {SlugComponent && <SlugComponent />}
+                      </>
+                    )}
+                  </TableHeader>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHead>
+        <TableBody>
+          {table
+            .getRowModel()
+            .rows.slice(0, 10)
+            .map((row) => {
+              return (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => {
+                    const isAiCell = cell.column.columnDef.meta?.slug;
+                    return (
+                      <TableCell
+                        key={cell.id}
+                        className={cx({
+                          ['ai-cell']: typeof isAiCell !== 'undefined',
+                        })}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/react/ai-label/src/Example/FullTableAi.tsx
+++ b/react/ai-label/src/Example/FullTableAi.tsx
@@ -7,6 +7,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { DataTable, TableContainer } from '@carbon/react';
+import { ExampleAiLabel } from './ExampleAiLabel';
 import cx from 'classnames';
 
 const { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } =
@@ -53,7 +54,10 @@ export const FullTableAI = () => {
   });
 
   return (
-    <TableContainer title="Full table" className="tanstack-example">
+    <TableContainer
+      title="Full table"
+      className="tanstack-example full-table-ai-wrapper">
+      <ExampleAiLabel size="sm" className="ai-full-table-label" />
       <Table className="ai-column-example full-table-ai">
         <TableHead>
           {table.getHeaderGroups().map((headerGroup) => (

--- a/react/ai-label/src/Example/FullTableAi.tsx
+++ b/react/ai-label/src/Example/FullTableAi.tsx
@@ -8,7 +8,6 @@ import {
 } from '@tanstack/react-table';
 import { DataTable, TableContainer } from '@carbon/react';
 import cx from 'classnames';
-import { ExampleAiLabel } from './ExampleAiLabel';
 
 const { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } =
   DataTable;

--- a/react/ai-label/src/Example/example.scss
+++ b/react/ai-label/src/Example/example.scss
@@ -76,3 +76,29 @@ tr.ai-row {
 .cds--data-table td.ai-cell-select {
   padding-inline-end: 0;
 }
+
+.full-table-ai tbody {
+  position: relative;
+}
+
+.full-table-ai tbody::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+
+  // Prevents the pseudo element overlay from obstructing click on elements below the overlay
+  pointer-events: none;
+  /* stylelint-disable */
+  background: linear-gradient(
+    to top,
+    var(--cds-ai-aura-start-sm, rgba(69, 137, 255, 0.16)) 0%,
+    var(--cds-ai-aura-end, rgba(255, 255, 255, 0)) 50%,
+    transparent 50%
+  );
+  /* stylelint-enable */
+
+  // Full table gradient needs to start from bottom which isn't configurable from this mixin yet
+  // @include utilities.ai-table-gradient;
+}

--- a/react/ai-label/src/Example/example.scss
+++ b/react/ai-label/src/Example/example.scss
@@ -1,8 +1,14 @@
 @use '@carbon/react/scss/theme' as *;
+@use '@carbon/react/scss/themes';
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/utilities';
+@use '@carbon/react/scss/utilities/ai-gradient' as *;
 @use '@carbon/react/scss/colors';
 @use '@carbon/react/scss/type';
+
+:root {
+  @include theme(themes.$white, true); // light default
+}
 
 .page-grid {
   margin-top: 4rem;
@@ -77,6 +83,29 @@ tr.ai-row {
   padding-inline-end: 0;
 }
 
+.full-table-ai-wrapper {
+  position: relative;
+
+  // Allow for pseudo element to show for gradient border effect
+  padding: 2px;
+  border: none;
+}
+
+.full-table-ai-wrapper::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+    to top,
+    $ai-border-end,
+    $ai-popover-shadow-outer-01
+  );
+  z-index: -1;
+}
+
 .full-table-ai tbody {
   position: relative;
 }
@@ -101,4 +130,11 @@ tr.ai-row {
 
   // Full table gradient needs to start from bottom which isn't configurable from this mixin yet
   // @include utilities.ai-table-gradient;
+}
+
+// Ideally TableContainer would support the decorator prop and custom styling would be avoided
+.ai-full-table-label {
+  top: 1rem;
+  right: 1rem;
+  align-items: start;
 }


### PR DESCRIPTION
[Preview](https://stackblitz.com/github/carbon-design-system/tanstack-carbon/tree/full-table-gradient/react/ai-label)

Notes:
- `ai-table-gradient` sass mixin should support some type of way to control the direction of the gradient, otherwise this will have to be implemented without the mixin
- `TableContainer` should support a `decorator` prop to implement the given design without custom stlying/placement of the AI Label

![image](https://github.com/user-attachments/assets/76d8f024-ff66-4701-9d70-58d9b42703e0)
