### PR TITLE
fix: add allowHost config for react and wc apps to fix codeSandBox

### DIFF
--- a/react/ai-label/vite.config.ts
+++ b/react/ai-label/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/batch-actions/vite.config.ts
+++ b/react/batch-actions/vite.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   },
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/batch-actions/vite.config.ts
+++ b/react/batch-actions/vite.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
       },
     },
   },
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/column-alignment/vite.config.ts
+++ b/react/column-alignment/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/column-alignment/vite.config.ts
+++ b/react/column-alignment/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/customizeColumns/vite.config.ts
+++ b/react/customizeColumns/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/customizeColumns/vite.config.ts
+++ b/react/customizeColumns/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/dynamic-nested-rows/vite.config.ts
+++ b/react/dynamic-nested-rows/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/dynamic-nested-rows/vite.config.ts
+++ b/react/dynamic-nested-rows/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/editableCells/vite.config.ts
+++ b/react/editableCells/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/editableCells/vite.config.ts
+++ b/react/editableCells/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/filterFlyout/vite.config.ts
+++ b/react/filterFlyout/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/filterFlyout/vite.config.ts
+++ b/react/filterFlyout/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/filterPanel/vite.config.ts
+++ b/react/filterPanel/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/filterPanel/vite.config.ts
+++ b/react/filterPanel/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/globalFilter/vite.config.ts
+++ b/react/globalFilter/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/globalFilter/vite.config.ts
+++ b/react/globalFilter/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/infiniteScroll/vite.config.ts
+++ b/react/infiniteScroll/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/infiniteScroll/vite.config.ts
+++ b/react/infiniteScroll/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/mix-and-match/vite.config.ts
+++ b/react/mix-and-match/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/mix-and-match/vite.config.ts
+++ b/react/mix-and-match/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/nestedRows/vite.config.ts
+++ b/react/nestedRows/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/nestedRows/vite.config.ts
+++ b/react/nestedRows/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/pagination/vite.config.ts
+++ b/react/pagination/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/pagination/vite.config.ts
+++ b/react/pagination/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/resizing/vite.config.ts
+++ b/react/resizing/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/resizing/vite.config.ts
+++ b/react/resizing/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/row-actions/vite.config.ts
+++ b/react/row-actions/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/row-actions/vite.config.ts
+++ b/react/row-actions/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/row-click/vite.config.ts
+++ b/react/row-click/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/row-click/vite.config.ts
+++ b/react/row-click/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/row-settings/vite.config.ts
+++ b/react/row-settings/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/row-settings/vite.config.ts
+++ b/react/row-settings/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/rowExpansion/vite.config.ts
+++ b/react/rowExpansion/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/rowExpansion/vite.config.ts
+++ b/react/rowExpansion/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/selectable-nested-rows/vite.config.ts
+++ b/react/selectable-nested-rows/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/selectable-nested-rows/vite.config.ts
+++ b/react/selectable-nested-rows/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/sortable/vite.config.ts
+++ b/react/sortable/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/sortable/vite.config.ts
+++ b/react/sortable/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/sticky-columns/vite.config.ts
+++ b/react/sticky-columns/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/sticky-columns/vite.config.ts
+++ b/react/sticky-columns/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/tabbed-header/vite.config.ts
+++ b/react/tabbed-header/vite.config.ts
@@ -4,4 +4,8 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/react/tabbed-header/vite.config.ts
+++ b/react/tabbed-header/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/virtual/vite.config.ts
+++ b/react/virtual/vite.config.ts
@@ -14,6 +14,6 @@ export default defineConfig({
   },
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });

--- a/react/virtual/vite.config.ts
+++ b/react/virtual/vite.config.ts
@@ -12,4 +12,8 @@ export default defineConfig({
       },
     },
   },
+  server: {
+    host: true,
+    allowedHosts: ['.csb.app'],
+  },
 });

--- a/web-components/ai-label/vite.config.ts
+++ b/web-components/ai-label/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/ai-label/vite.config.ts
+++ b/web-components/ai-label/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/ai-label/vite.config.ts
+++ b/web-components/ai-label/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/basic/vite.config.ts
+++ b/web-components/basic/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/basic/vite.config.ts
+++ b/web-components/basic/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/basic/vite.config.ts
+++ b/web-components/basic/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/batch-actions/vite.config.ts
+++ b/web-components/batch-actions/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/batch-actions/vite.config.ts
+++ b/web-components/batch-actions/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/batch-actions/vite.config.ts
+++ b/web-components/batch-actions/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/column-alignment/vite.config.ts
+++ b/web-components/column-alignment/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/column-alignment/vite.config.ts
+++ b/web-components/column-alignment/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/column-alignment/vite.config.ts
+++ b/web-components/column-alignment/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/customize-columns/vite.config.ts
+++ b/web-components/customize-columns/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/customize-columns/vite.config.ts
+++ b/web-components/customize-columns/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/customize-columns/vite.config.ts
+++ b/web-components/customize-columns/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/dynamic-nested-rows/vite.config.ts
+++ b/web-components/dynamic-nested-rows/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/dynamic-nested-rows/vite.config.ts
+++ b/web-components/dynamic-nested-rows/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/dynamic-nested-rows/vite.config.ts
+++ b/web-components/dynamic-nested-rows/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/editable-cells/vite.config.ts
+++ b/web-components/editable-cells/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/editable-cells/vite.config.ts
+++ b/web-components/editable-cells/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/editable-cells/vite.config.ts
+++ b/web-components/editable-cells/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/filter-flyout/vite.config.ts
+++ b/web-components/filter-flyout/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/filter-flyout/vite.config.ts
+++ b/web-components/filter-flyout/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/filter-flyout/vite.config.ts
+++ b/web-components/filter-flyout/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/filter-panel/vite.config.ts
+++ b/web-components/filter-panel/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/filter-panel/vite.config.ts
+++ b/web-components/filter-panel/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/filter-panel/vite.config.ts
+++ b/web-components/filter-panel/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/global-filter/vite.config.ts
+++ b/web-components/global-filter/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/global-filter/vite.config.ts
+++ b/web-components/global-filter/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/global-filter/vite.config.ts
+++ b/web-components/global-filter/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/infinite-scroll/vite.config.ts
+++ b/web-components/infinite-scroll/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/infinite-scroll/vite.config.ts
+++ b/web-components/infinite-scroll/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/infinite-scroll/vite.config.ts
+++ b/web-components/infinite-scroll/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/nested-rows/vite.config.ts
+++ b/web-components/nested-rows/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/nested-rows/vite.config.ts
+++ b/web-components/nested-rows/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/nested-rows/vite.config.ts
+++ b/web-components/nested-rows/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/pagination/vite.config.ts
+++ b/web-components/pagination/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/pagination/vite.config.ts
+++ b/web-components/pagination/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/pagination/vite.config.ts
+++ b/web-components/pagination/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/resizing/vite.config.ts
+++ b/web-components/resizing/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/resizing/vite.config.ts
+++ b/web-components/resizing/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/resizing/vite.config.ts
+++ b/web-components/resizing/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/row-actions/vite.config.ts
+++ b/web-components/row-actions/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/row-actions/vite.config.ts
+++ b/web-components/row-actions/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/row-actions/vite.config.ts
+++ b/web-components/row-actions/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/row-click/vite.config.ts
+++ b/web-components/row-click/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/row-click/vite.config.ts
+++ b/web-components/row-click/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/row-click/vite.config.ts
+++ b/web-components/row-click/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/row-expansion/vite.config.ts
+++ b/web-components/row-expansion/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/row-expansion/vite.config.ts
+++ b/web-components/row-expansion/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/row-expansion/vite.config.ts
+++ b/web-components/row-expansion/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/row-settings/vite.config.ts
+++ b/web-components/row-settings/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/row-settings/vite.config.ts
+++ b/web-components/row-settings/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/row-settings/vite.config.ts
+++ b/web-components/row-settings/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/selectable-nested-rows/vite.config.ts
+++ b/web-components/selectable-nested-rows/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/selectable-nested-rows/vite.config.ts
+++ b/web-components/selectable-nested-rows/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/selectable-nested-rows/vite.config.ts
+++ b/web-components/selectable-nested-rows/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/sortable/vite.config.ts
+++ b/web-components/sortable/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/sortable/vite.config.ts
+++ b/web-components/sortable/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/sortable/vite.config.ts
+++ b/web-components/sortable/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/sticky-columns/vite.config.ts
+++ b/web-components/sticky-columns/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/sticky-columns/vite.config.ts
+++ b/web-components/sticky-columns/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/sticky-columns/vite.config.ts
+++ b/web-components/sticky-columns/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/tabbed-header/vite.config.ts
+++ b/web-components/tabbed-header/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/tabbed-header/vite.config.ts
+++ b/web-components/tabbed-header/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/tabbed-header/vite.config.ts
+++ b/web-components/tabbed-header/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 

--- a/web-components/virtual/vite.config.ts
+++ b/web-components/virtual/vite.config.ts
@@ -1,11 +1,11 @@
 import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
   server: {
     host: true,
     allowedHosts: ['.csb.app'],
   },
 });
+
+

--- a/web-components/virtual/vite.config.ts
+++ b/web-components/virtual/vite.config.ts
@@ -7,5 +7,3 @@ export default defineConfig({
     allowedHosts: true,
   },
 });
-
-

--- a/web-components/virtual/vite.config.ts
+++ b/web-components/virtual/vite.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   server: {
     host: true,
-    allowedHosts: ['.csb.app'],
+    allowedHosts: true,
   },
 });
 


### PR DESCRIPTION
While opening any react or wc app in code sandbox throw below error. This PR add configuration in vite.config to allow this particular host

> Blocked request. This host ("cg982l-5173.csb.app") is not allowed.
> To allow this host, add "cg982l-5173.csb.app" to `server.allowedHosts` in vite.config.js.